### PR TITLE
Add a notebook to analyse Q's 1 and 3

### DIFF
--- a/analyse-responses.ipynb
+++ b/analyse-responses.ipynb
@@ -143,9 +143,9 @@
  ],
  "metadata": {
   "kernelspec": {
-    "name": "python3",
-    "display_name": "Python 3",
-    "language": "python"
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
This PR adds a notebook that analyses the data from the questions 1 and 3 of the mybinder.org Feb 2020 user survey.

- [x] Question 1
- [x] Question 3