### PR TITLE
Bump python runtime version to 3.9

### DIFF
--- a/.binder/runtime.txt
+++ b/.binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7
+python-3.9


### PR DESCRIPTION
Dependencies were broken in Binder because we were loading an old-ish version of Python